### PR TITLE
Add generic schemas and JSON schemas for Money and Decimal.

### DIFF
--- a/json_schema/decimal.yaml
+++ b/json_schema/decimal.yaml
@@ -1,0 +1,39 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://example.com/product.schema.json
+title: Decimal
+description: |
+  Represents a decimal number in a form similar to scientific notation.
+
+  Examples:
+  17            === {"significand": 17,   "exponent": 0}
+  -0.005        === {"significand": -5,   "exponent": -3}
+  33.5 million  === {"significand": 335,  "exponent": 5}
+  11/8 (1.375)  === {"significand": 1375, "exponent": -3}
+
+  Note that the range of a Decmial exceeds that of a JSON `number` (double),
+  as well as that of a `decimal64`.
+type: object
+required:
+- significand
+- exponent
+additionalProperties: false
+properties:
+  significand:
+    description: The significant digits of the number.
+    type: integer
+    format: int64
+  exponent:
+    description: |
+      Represents the position of the decimal point within the significand.
+
+      When the exponent is 0, the value of the Decimal is simply the value of
+      `significand`.
+
+      When the exponent is greater than 0, represents the number of trailing
+      zeroes after the significant digits.
+
+      When the exponent is < less than, represents how many of the
+      significant digits (and implicit leading zeroes, as needed) come after
+      the decmial point.
+    type: integer
+    format: int32

--- a/json_schema/money.yaml
+++ b/json_schema/money.yaml
@@ -1,0 +1,36 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://example.com/product.schema.json
+title: Money
+description: |
+  Represents an amount of money with its currency type.
+
+  Examples:
+
+  Five US dollars === `{"currency_code": "USD", "quantity": {"significand": 5}}`
+  One and a half Bitcoin ===
+    `{"currency_code": "X-BTC", "quantity": {"significand": 15, "exponent": -1}}`
+type: object
+required:
+- currency_code
+- quantity
+additionalProperties: false
+properties:
+  currency_code:
+    description: |
+      A currency code.
+
+      This may be a three-letter currency code defined in ISO 4217.
+
+      APIs may define additional currency codes that are not included in the ISO
+      4217 standard (for example, virtual currencies or cryptocurrencies). These
+      must start with "X-", in order to distinguish them from potential future
+      ISO 4217 codes.
+
+      Examples:
+        "USD"  - ISO 4217 code for United States dollar.
+        "X-BTC" - Potential API-defined extension for Bitcoin.
+        "X-RBX" - Potential API-defined extension for the virtual currency Robux.
+    type: string
+  quantity:
+    description: The quantity of currency.
+    $ref: decimal.yaml#/definitions/Decimal

--- a/schemas/type/decimal.md
+++ b/schemas/type/decimal.md
@@ -1,0 +1,40 @@
+# Decimal
+
+The `Decimal` type represents a decimal numeric value. It uses a non-floating
+point representation in order to avoid precision errors.
+
+## Schema
+
+A `Decimal` represents a decimal number in a form similar to scientific
+notation.
+
+It has two fields:
+
+- The `significand` field is a 64-bit integer representing the significant
+  digits of the number.
+- The `exponent` field is a 32-bit integer represesnting the position of the
+  deicmal point within the value of the `significand` field; it is the power of
+  ten to which `significand` should be raised.
+
+  When the exponent is `0`, the value of the `Decimal` is simply the value of
+  `significand`.
+
+  When the exponent is greater than 0, represents the number of trailing zeroes
+  after the significant digits.
+
+  When the exponent is less than 0, represents how many of the significant
+  digits (and implicit leading zeroes, as needed) come after the decimal point.
+
+The general formula for converting a `Decimal` to its numeric value is
+`significant * 10^exponent`, where `*` represents multplication and `^`
+represents exponentiation.
+
+Note: The range of a Decmial exceeds that of a JSON `number` (double), as well
+as that of a `decimal64`.
+
+## Examples
+
+- 17 === `{significand: 17, exponent: 0}`
+- -0.005 === `{significand: -5, exponent: -3}`
+- 33.5 million === `{significand: 335, exponent: 5}`
+- 11/8 === 1.375 === `{significand: 1375, exponent: -3}`

--- a/schemas/type/money.md
+++ b/schemas/type/money.md
@@ -1,0 +1,35 @@
+# Money
+
+The `Money` type represents an amount of money in a specified currency.
+
+## Schema
+
+A `Money` has two fields:
+
+- The `currency_code` field is a string containing a currency code.
+
+  The three-letter currency codes defined in the ISO 4217 standard are always
+  supported.
+
+  APIs may define additional currency codes that are not included in ISO 4217
+  (for example, virtual currencies or cryptocurrencies). These must start with
+  with "X-", in order to distinguish them from potential future ISO 4217 codes.
+
+  Examples:
+
+  - "USD" - ISO 4217 code for United States dollar
+  - "X-BTC" - Potential API-defined extension for Bitcoin.
+  - "X-.RBX" - Potential API-defined extension for the virtual currency Robux
+
+- The `quantity` field is a field of type [`Decimal`][], representing the
+  quantity of currency.
+
+## Examples
+
+- Five US dollars === `{currency_code: "USD", quantity: {significand: 5}}`
+- One and a half Bitcoin ===
+  `{currency_code: "X-BTC", quantity: {significand: 15, exponent: -1}}`
+
+<!--prettier-ignore-start-->
+[`Decimal`]: ./decimal.md
+<!--prettier-ignore-end-->


### PR DESCRIPTION
These are copied from the existing schemas in the `common-components` directory of aep-dev/aep.dev; they were there temporarily as an artifact of issues with our GitHub organization setup.