### PR TITLE
Import (relevant parts of) .github from aep-dev/aep.dev.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The AEP maintainers team owns the content of this repository.
+*   @aep-dev/maintainers

--- a/.github/workflows/build-and-publish-protos.yaml
+++ b/.github/workflows/build-and-publish-protos.yaml
@@ -1,0 +1,22 @@
+---
+name: build-and-publish-protos
+on:
+  pull_request:
+    paths:
+      - 'proto/**/*.proto'
+jobs:
+  build-and-publish-protos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: bufbuild/buf-setup-action@v1.19.0
+
+      - name: Verify that protos build.
+        run: buf build
+
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          buf_token: ${{ secrets.BUF_TOKEN }}
+          input: proto
+          draft: ${{ github.ref_name != 'main'}}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+---
+name: lint
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: node:20
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install prettier.
+        run: npm install --global prettier
+      - name: Verify proper formatting.
+        run: prettier --check **/*.md **/*.md.j2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Install prettier.
         run: npm install --global prettier
       - name: Verify proper formatting.
-        run: prettier --check **/*.md **/*.md.j2
+        run: prettier --check **/*.md


### PR DESCRIPTION
Also, modify the build-and-publish-protos workflow to reflect different directory structure in this repo.

The presence of a `buf.work.yaml` complicates the changes a bit; I didn't just remove `common-components/` but also `proto/`.  I don't know if this is correct overall, but it does make `buf build` pass (whereas `buf build proto` fails).

I also don't know why we need proto/aep-conformance in this repo.

And finally, I used a personal token for `BUF_TOKEN` because I can't figure out if Buf supports org tokens.

@Alfus would appreciate input on all of the above.