### PR TITLE
Adding format field to FieldInfo

### DIFF
--- a/proto/aep-api/aep/api/field_info.proto
+++ b/proto/aep-api/aep/api/field_info.proto
@@ -22,6 +22,38 @@ extend google.protobuf.FieldOptions {
 //
 // This is, conceptually, supplementary to `google.api.FieldInfo`.
 message FieldInfo {
+  // The standard format of a field value. The supported formats are all backed
+  // by either an RFC defined by the IETF or an AEP.
+  enum Format {
+    // Default, unspecified value.
+    FORMAT_UNSPECIFIED = 0;
+
+    // Universally Unique Identifier, version 4, value as defined by
+    // https://datatracker.ietf.org/doc/html/rfc4122. The value may be
+    // normalized to entirely lowercase letters. For example, the value
+    // `F47AC10B-58CC-0372-8567-0E02B2C3D479` would be normalized to
+    // `f47ac10b-58cc-0372-8567-0e02b2c3d479`.
+    UUID4 = 1;
+
+    // Internet Protocol v4 value as defined by [RFC
+    // 791](https://datatracker.ietf.org/doc/html/rfc791). The value may be
+    // condensed, with leading zeros in each octet stripped. For example,
+    // `001.022.233.040` would be condensed to `1.22.233.40`.
+    IPV4 = 2;
+
+    // Internet Protocol v6 value as defined by [RFC
+    // 2460](https://datatracker.ietf.org/doc/html/rfc2460). The value may be
+    // normalized to entirely lowercase letters with zeros compressed, following
+    // [RFC 5952](https://datatracker.ietf.org/doc/html/rfc5952). For example,
+    // the value `2001:0DB8:0::0` would be normalized to `2001:db8::`.
+    IPV6 = 3;
+
+    // An IP address in either v4 or v6 format as described by the individual
+    // values defined herein. See the comments on the IPV4 and IPV6 types for
+    // allowed normalizations of each.
+    IPV4_OR_IPV6 = 4;
+  }
+
   // The minimum guaranteed duration for which the field value applies.
   //
   // For example, if an `idempotency_key` field has a lifetime of one hour, then
@@ -33,4 +65,9 @@ message FieldInfo {
   // the minimum lifetime is a strict cutoff. For example, an API may honor an
   // idempotency key indefinitely, whatever the value of this field option.
   google.protobuf.Duration minimum_lifetime = 1;
+
+  // The standard format of a field value. This does not explicitly configure
+  // any API consumer, just documents the API's format for the field it is
+  // applied to.
+  Format format = 2;
 }


### PR DESCRIPTION
AEP 202 ([PR](https://github.com/aep-dev/aep.dev/pull/155)) refers to the Format field in `google.api.FieldInfo`. This adds the Format field to the AEP version.